### PR TITLE
Update conftest version to 0.20.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "conftest"
-version: "0.18.1"
+version: "0.20.0"
 usage: "Test Helm Charts"
 description: |-
   "Test your Helm Charts with Open Policy Agent"


### PR DESCRIPTION
Would it be possible to also update the corresponding Docker image (https://hub.docker.com/r/instrumenta/helm-conftest) ?